### PR TITLE
20790: Add variable frontend_editing

### DIFF
--- a/modules/hanna-twig/src/ExtraLinks.twig
+++ b/modules/hanna-twig/src/ExtraLinks.twig
@@ -6,6 +6,7 @@
 ] %}
 
 <div {{ attributes.addClass(classes) }}>
+	{{ frontend_editing }}
 	{# Main section with boxes. #}
 	<div class="ExtraLinks__main">
 		<h2 class="ExtraLinks__title">{{extraLinks_main_title}}</h2>

--- a/modules/hanna-twig/src/ExtraLinksCard.twig
+++ b/modules/hanna-twig/src/ExtraLinksCard.twig
@@ -3,6 +3,7 @@
 {% else %}
 	<li class="ExtraLinks__item">
 {% endif %}
+	{{ frontend_editing }}
 	{{ content.contextual_links }}
 	<a class="ExtraLinks__card" href="{{ url }}">
 		<span class="ExtraLinks__card__title">{{ title }}</span>

--- a/modules/hanna-twig/src/GridBlocks.twig
+++ b/modules/hanna-twig/src/GridBlocks.twig
@@ -10,6 +10,7 @@
 {{ attach_library('storybook/GridBlocks') }}
 
 <div class="GridBlocks__item">
+	{{ frontend_editing }}
 	<picture class="GridBlocks__illustration">
 		{{ grid_image }}
 	</picture>

--- a/modules/hanna-twig/src/ImageCards.twig
+++ b/modules/hanna-twig/src/ImageCards.twig
@@ -14,6 +14,7 @@
 %}
 
 <div{{ attributes.addClass(classes).setAttribute('style', fallbackStyleAttr) }}>
+  {{ frontend_editing }}
   {% if more_link %}
     <div class="ImageCards__summary">
       {% if image_cards_title %}

--- a/modules/hanna-twig/src/IslandBlock.twig
+++ b/modules/hanna-twig/src/IslandBlock.twig
@@ -9,6 +9,7 @@
 %}
 
 <div {{ attributes.setAttribute('class', classes) }}>
+	{{ frontend_editing }}
 	{% block contextual %}{% endblock contextual %}
 
 	{% for contentItem in IslandBlock_content %}

--- a/modules/hanna-twig/src/IslandBlockText.twig
+++ b/modules/hanna-twig/src/IslandBlockText.twig
@@ -1,4 +1,5 @@
 <div class="IslandBlock__content">
+	{{ frontend_editing }}
 	<h2 class="IslandBlock__title">{{ IslandBlock_title }}</h2>
 	<div class="IslandBlock__summary">{{ IslandBlock_summary }}</div>
 	{% if IslandBlock_buttons %}


### PR DESCRIPTION
**Issue**
https://dev.azure.com/reykjavikurborg/Dev/_workitems/edit/20790

**Description**
The new version of Frontend Editing module needs to print variable **content.frontend_editing** in the templates to actually see the action buttons- Most of these printings had been done in the main templates of the repo, but for others has been impossible because they embed a hanna component and to not redo the html or styling, this is the easiest solution found for these 6 templates.