### PR TITLE
Storybook fullscreen icon

### DIFF
--- a/modules/html-storybook/.storybook/manager.ts
+++ b/modules/html-storybook/.storybook/manager.ts
@@ -10,7 +10,6 @@ addons.setConfig({
   selectedPanel: 'storybook/html/panel',
   toolbar: {
     zoom: { hidden: true },
-    fullscreen: { hidden: true },
     eject: { hidden: true },
     copy: { hidden: true },
     remount: { hidden: true },


### PR DESCRIPTION
**Changes**:
The "fullscreen" icon was removed from the toolbar in storybook. This simple config change adds it back. The icon will appear at the right side of the toolbar.

![sb](https://github.com/rvk-utd/hanna/assets/83654289/443cb975-aafd-4e56-a7c7-ebf94708659e)
