### PR TITLE
22758: update hanna twig templates to use new storybook path

### DIFF
--- a/modules/hanna-twig/src/ContentArticle.twig
+++ b/modules/hanna-twig/src/ContentArticle.twig
@@ -17,12 +17,12 @@
 
 <div class="ContentArticle">
 	<div class="ContentArticle__header">
-		{% include "@storybook/Heading/Heading.twig" with {
+		{% include "@storybook/Heading.twig" with {
       forceH1: 'true',
       title: label
     }%}
 
-		{% include "@storybook/ArticleMeta/ArticleMeta.twig" with {
+		{% include "@storybook/ArticleMeta.twig" with {
       items: articleMeta,
     }%}
 
@@ -41,19 +41,19 @@
 	}%}
 
 	{% if relatedItems is defined and relatedItems|length > 0 %}
-		{% include "@storybook/VSpacer/VSpacer.twig" with {
+		{% include "@storybook/VSpacer.twig" with {
 			size: 'true',
 			small: 'small',
 			content: '<hr/>'
 		}%}
 
-		{% include "@storybook/RelatedLinks/RelatedLinks.twig" with {
+		{% include "@storybook/RelatedLinks.twig" with {
 			title: 'Related material'|trans,
 			items: relatedItems
 		}%}
 	{% endif %}
 
-	{% include "@storybook/VSpacer/VSpacer.twig" with {
+	{% include "@storybook/VSpacer.twig" with {
 		size: 'true',
 		small: 'small',
 		content: ''

--- a/modules/hanna-twig/src/Layout.twig
+++ b/modules/hanna-twig/src/Layout.twig
@@ -50,7 +50,7 @@
 		</div>
 		<div class="Layout__footer" role="complementary">
 			{% include '@reykjavik/layout/footer.html.twig' %}
-			{% include "@storybook/Footer/FooterBadges.twig" %}
+			{% include "@storybook/FooterBadges.twig" %}
 		</div>
 	</div>
 </div>

--- a/modules/hanna-twig/src/MainMenu.twig
+++ b/modules/hanna-twig/src/MainMenu.twig
@@ -64,7 +64,7 @@
 						</li>
 					{% endif %}
 				{% endfor %}
-				{% include "@storybook/nav/_Auxiliary.twig" with menu_auxiliarPanel %}
+				{% include "@storybook/_Auxiliary.twig" with menu_auxiliarPanel %}
 				</ul>
 		</div>
 	{% endif %}

--- a/modules/hanna-twig/src/MainMenuItem.twig
+++ b/modules/hanna-twig/src/MainMenuItem.twig
@@ -4,7 +4,7 @@
 ] %}
 
 <li {{ attributes.setAttribute('class', classes) }}>
-	{% include "@storybook/Buttons/Button.twig" with {
+	{% include "@storybook/Button.twig" with {
 		button_class: 'MainMenu__link',
 		button_url: menuitem_link,
 		button_text: menuitem_label


### PR DESCRIPTION
This PR add changes in some twig templates used in hanna repository. The changes are needed due to storybook Drupal path has changed to match the new hanna-twig folder used in  hanna repository. components and twig templates are not anymore grouped by name