### PR TITLE
Feature/22758 switch hanna rollback

### DIFF
--- a/modules/hanna-twig/src/ContentArticle.twig
+++ b/modules/hanna-twig/src/ContentArticle.twig
@@ -2,7 +2,7 @@
 
 {% if image %}
 	{% set topImage %}
-	{% include "@storybook/ContentImage/ContentImage.twig" with{
+	{% include "@storybook/ContentImage.twig" with{
 			text: imageText,
 			credit: imageCredit,
 			image: image,
@@ -36,7 +36,7 @@
 		{% endif %}
 	</div>
 
-	{% include "@storybook/TextBlock/TextBlock.twig" with {
+	{% include "@storybook/TextBlock.twig" with {
 		content: contentText
 	}%}
 

--- a/modules/hanna-twig/src/ContentArticle.twig
+++ b/modules/hanna-twig/src/ContentArticle.twig
@@ -2,7 +2,7 @@
 
 {% if image %}
 	{% set topImage %}
-	{% include "./ContentImage.twig" with{
+	{% include "@storybook/ContentImage/ContentImage.twig" with{
 			text: imageText,
 			credit: imageCredit,
 			image: image,
@@ -17,12 +17,12 @@
 
 <div class="ContentArticle">
 	<div class="ContentArticle__header">
-		{% include "./Heading.twig" with {
+		{% include "@storybook/Heading.twig" with {
       forceH1: 'true',
       title: label
     }%}
 
-		{% include "./ArticleMeta.twig" with {
+		{% include "@storybook/ArticleMeta.twig" with {
       items: articleMeta,
     }%}
 
@@ -36,24 +36,24 @@
 		{% endif %}
 	</div>
 
-	{% include "./TextBlock.twig" with {
+	{% include "@storybook/TextBlock/TextBlock.twig" with {
 		content: contentText
 	}%}
 
 	{% if relatedItems is defined and relatedItems|length > 0 %}
-		{% include "./VSpacer.twig" with {
+		{% include "@storybook/VSpacer.twig" with {
 			size: 'true',
 			small: 'small',
 			content: '<hr/>'
 		}%}
 
-		{% include "./RelatedLinks.twig" with {
+		{% include "@storybook/RelatedLinks.twig" with {
 			title: 'Related material'|trans,
 			items: relatedItems
 		}%}
 	{% endif %}
 
-	{% include "./VSpacer.twig" with {
+	{% include "@storybook/VSpacer.twig" with {
 		size: 'true',
 		small: 'small',
 		content: ''

--- a/modules/hanna-twig/src/Layout.twig
+++ b/modules/hanna-twig/src/Layout.twig
@@ -44,7 +44,7 @@
 		</div>
 		<div class="Layout__footer" role="complementary">
 			{% include '@reykjavik/layout/footer.html.twig' %}
-			{% include "./FooterBadges.twig" %}
+			{% include "@storybook/FooterBadges.twig" %}
 		</div>
 	</div>
 </div>

--- a/modules/hanna-twig/src/MainMenu.twig
+++ b/modules/hanna-twig/src/MainMenu.twig
@@ -64,7 +64,7 @@
 						</li>
 					{% endif %}
 				{% endfor %}
-				{% include "./_Auxiliary.twig" with menu_auxiliarPanel %}
+				{% include "@storybook/_Auxiliary.twig" with menu_auxiliarPanel %}
 				</ul>
 		</div>
 	{% endif %}

--- a/modules/hanna-twig/src/MainMenuItem.twig
+++ b/modules/hanna-twig/src/MainMenuItem.twig
@@ -4,7 +4,7 @@
 ] %}
 
 <li {{ attributes.setAttribute('class', classes) }}>
-	{% include "./Button.twig" with {
+	{% include "@storybook/Button.twig" with {
 		button_class: 'MainMenu__link',
 		button_url: menuitem_link,
 		button_text: menuitem_label


### PR DESCRIPTION
This PR set back twig namespace @storybook as part of some templates that use drupal.
We decided to use relative path but that;s unsupported so w have to switch back.
@maranomynet I think hanna should not have in use a namespace that it is defined outside itself but Drupal require use namespace or absolute path 

-     https://www.drupal.org/docs/contributed-modules/components/understanding-twig-namespaces
-     https://www.drupal.org/project/components

If the twig file is allocated in /template folder in the theme we could use it but it will require move some files to template folder after the theme is pull in Drupal (we did something similar with some js files time ago)

Said that I think we have 2 solutions here:
* Use a namespace and indicate in hanna Drupal use case that a namespace named "storybook" needs to be added to Drupal thame
* Move twig files that are used in other twig files to template folder after theme installation.

I think the best approach is use namespace because hanna is using twig template only for Drupal so it could make sense force to define a namespace BUT I understand the confusion that it could generate. 
On the ohter hand, move files to template folder could generate problems if user has another file with the same twig file and will need to adjust deployment process to build the theme correctly.
What do you think about it @maranomynet ?