### PR TITLE
24479: Create Carousel sprinkle

### DIFF
--- a/modules/hanna-sprinkles/src/Carousel.tsx
+++ b/modules/hanna-sprinkles/src/Carousel.tsx
@@ -1,0 +1,48 @@
+import './_/initHannaNamespace.js';
+
+import React, {ReactNode} from 'react';
+import ReactDOM from 'react-dom';
+import qq from '@hugsmidjan/qj/qq';
+import { Carousel, CarouselProps } from '@reykjavik/hanna-react/Carousel';
+
+import { autoSeenEffectsRefresh, autoSeenEffectWrapperProps } from './_/addSeenEffect.js';
+
+const getCarouselData = (elm: HTMLElement): CarouselProps => {
+  const items = qq<HTMLElement>('.Carousel__itemlist', elm).map(
+    (itemElm: HTMLElement): ReactNode => {
+      const items = Array.from(itemElm.children).map((child) => {
+        const childHTML = child.innerHTML;
+        // eslint-disable-next-line react/jsx-key
+        return <div dangerouslySetInnerHTML={{ __html: childHTML }} />;
+      });
+
+      return items;
+    }
+  );
+
+  const children = items.flat();
+
+  return { children };
+};
+
+window.Hanna.makeSprinkle({
+  name: 'Carousel',
+
+  init: (elm: HTMLElement) => {
+    const props = getCarouselData(elm);
+    const root = elm;
+    elm.getAttributeNames().forEach((attrName) => {
+      elm.removeAttribute(attrName);
+    });
+
+    ReactDOM.render(
+      <Carousel {...props} ssr={false} wrapperProps={autoSeenEffectWrapperProps(elm)} />,
+      root,
+      () => autoSeenEffectsRefresh()
+    );
+    return root;
+  },
+  unmount: (elm: HTMLElement, root) => {
+    ReactDOM.unmountComponentAtNode(root);
+  },
+});


### PR DESCRIPTION
We need to use Carousel component in Drupal side to show a group of cards as was required in a task (24479)
The problem I found is the component needs its sprinkle to load the component properly in Drupal and be functional.

Due to the list of items we need to display are part of Drupal side I have to pass the data using children prop and the only way I found was using ` dangerouslySetInnerHTML`  (I think this is not ideal but what it is needed here).
I also think we Carousel should be extended to with a prop to pass children as HTML and allow the developer use ` dangerouslySetInnerHTML` or not , based on needs.

I'm not sure what;s the best approach here.