### PR TITLE
WEB-155: Add support to add Drupal FE links

### DIFF
--- a/modules/hanna-react/src/ArticleCarousel/_ArticleCarouselCard.tsx
+++ b/modules/hanna-react/src/ArticleCarousel/_ArticleCarouselCard.tsx
@@ -19,6 +19,7 @@ export type ArticleCarouselCardProps = {
    * then `color` takes precedence.
    */
   theme?: HannaColorTheme;
+  contextual?: string;
 } & (
   | {
       illustration: Illustration;
@@ -44,6 +45,7 @@ export const ArticleCarouselCard = (
     theme,
     illustration,
     image,
+    contextual,
   } = props;
 
   const photo = image?.photo;
@@ -55,6 +57,12 @@ export const ArticleCarouselCard = (
       data-color={color && colorFamilies[color]}
       data-color-theme={!color ? theme && themeOptions[theme] : undefined} // color takes precedence over "theme"
     >
+      {contextual && (
+        <div
+          className="ArticleCarouselCard__contextual"
+          dangerouslySetInnerHTML={{ __html: contextual }}
+        />
+      )}
       <Link className="ArticleCarouselCard__link" href={href} target={target}>
         {' '}
         <Image

--- a/modules/hanna-react/src/Gallery.tsx
+++ b/modules/hanna-react/src/Gallery.tsx
@@ -38,6 +38,7 @@ const defaultTexts: DefaultTexts<GalleryI18n> = {
 
 export type GalleryProps = {
   items: Array<GalleryItemProps>;
+  contextual?: string;
   texts?: GalleryI18n;
   lang?: HannaLang;
 } & SSRSupportProps &
@@ -45,7 +46,7 @@ export type GalleryProps = {
   DeprecatedSeenProp;
 
 export const Gallery = (props: GalleryProps) => {
-  const { items, ssr } = props;
+  const { items, ssr, contextual } = props;
   const texts = getTexts(props, defaultTexts);
   const [currentImage, setCurrentImage] = useState<GalleryItemProps | undefined>(
     undefined
@@ -60,6 +61,7 @@ export const Gallery = (props: GalleryProps) => {
       <AbstractCarousel
         bem="Gallery"
         items={items}
+        contextual={contextual}
         Component={GalleryItem}
         ssr={ssr}
         wrapperProps={props.wrapperProps}

--- a/modules/hanna-react/src/Gallery/_GalleryItem.tsx
+++ b/modules/hanna-react/src/Gallery/_GalleryItem.tsx
@@ -9,16 +9,22 @@ import { GalleryModalContext } from './_GalleryModalContext.js';
 
 export type GalleryItemProps = {
   caption?: string;
+  contextual?: string;
   description?: string;
   largeImageSrc?: string;
 } & ImageProps;
 
 export const GalleryItem = (props: GalleryItemProps) => {
-  const { caption, description, largeImageSrc, ...image } = props;
+  const { caption, contextual, description, largeImageSrc, ...image } = props;
   const { setCurrentImage } = useContext(GalleryModalContext);
-
   return (
     <figure className="GalleryItem">
+      {contextual && (
+        <div
+          className="GalleryItem__contextual"
+          dangerouslySetInnerHTML={{ __html: contextual }}
+        />
+      )}
       <figcaption className="GalleryItem__caption">{caption}</figcaption>
       {largeImageSrc ? (
         <Button

--- a/modules/hanna-react/src/_abstract/_AbstractCarousel.tsx
+++ b/modules/hanna-react/src/_abstract/_AbstractCarousel.tsx
@@ -72,7 +72,11 @@ export type CarouselProps<
 type AbstractCarouselProps<
   I extends Record<string, unknown> = Record<string, unknown>,
   P extends Record<string, unknown> | undefined = Record<string, unknown>
-> = CarouselProps<I, P> & BemProps & { title?: string };
+> = CarouselProps<I, P> &
+  BemProps & {
+    title?: string;
+    contextual?: string;
+  };
 
 // eslint-disable-next-line complexity
 export const AbstractCarousel = <
@@ -83,6 +87,7 @@ export const AbstractCarousel = <
 ) => {
   const {
     title,
+    contextual,
     items = [],
     Component,
     ComponentProps,
@@ -229,31 +234,39 @@ export const AbstractCarousel = <
       {title && <h2 className={`${bem}__title`}>{title}</h2>}
 
       {isBrowser ? (
-        <div className={`${bem}__itemlist-wrapper`}>
-          {itemList}
-          {activeItem > 0 && (
+        <>
+          {contextual && (
             <div
-              className={`${bem}__itemlist-goLeft`}
-              onClick={() => {
-                delayedScrollLeft.cancel();
-                scrollToItem(activeItem - 1);
-              }}
-              onMouseOver={() => delayedScrollLeft(activeItem)}
-              onMouseOut={() => delayedScrollLeft.cancel()}
+              className={`${bem}__contextual`}
+              dangerouslySetInnerHTML={{ __html: contextual }}
             />
           )}
-          {activeItem < itemCount - 1 && (
-            <div
-              className={`${bem}__itemlist-goRight`}
-              onClick={() => {
-                delayedScrollRight.cancel();
-                scrollToItem(activeItem + 1);
-              }}
-              onMouseOver={() => delayedScrollRight(activeItem)}
-              onMouseOut={() => delayedScrollRight.cancel()}
-            />
-          )}
-        </div>
+          <div className={`${bem}__itemlist-wrapper`}>
+            {itemList}
+            {activeItem > 0 && (
+              <div
+                className={`${bem}__itemlist-goLeft`}
+                onClick={() => {
+                  delayedScrollLeft.cancel();
+                  scrollToItem(activeItem - 1);
+                }}
+                onMouseOver={() => delayedScrollLeft(activeItem)}
+                onMouseOut={() => delayedScrollLeft.cancel()}
+              />
+            )}
+            {activeItem < itemCount - 1 && (
+              <div
+                className={`${bem}__itemlist-goRight`}
+                onClick={() => {
+                  delayedScrollRight.cancel();
+                  scrollToItem(activeItem + 1);
+                }}
+                onMouseOver={() => delayedScrollRight(activeItem)}
+                onMouseOut={() => delayedScrollRight.cancel()}
+              />
+            )}
+          </div>
+        </>
       ) : (
         itemList
       )}

--- a/modules/hanna-sprinkles/src/ArticleCarousel.tsx
+++ b/modules/hanna-sprinkles/src/ArticleCarousel.tsx
@@ -18,6 +18,10 @@ const getArticleCarouselData = (elm: HTMLElement): ArticleCarouselProps => {
   const title = q('.ArticleCarousel__title', elm)?.textContent || '';
   const items = qq<HTMLElement>('.ArticleCarouselCard', elm).map(
     (itemElm): ArticleCarouselCardProps => {
+      const contextual = q<HTMLDivElement>(
+        '.ArticleCarouselCard__contextual',
+        itemElm
+      )?.innerHTML;
       const img = q<HTMLImageElement>('.ArticleCarouselCard__illustration img', itemElm);
       const photo = !!q('.ArticleCarouselCard__illustration--photo', itemElm);
       const image: ArticleCarouselImageProps | undefined = img && {
@@ -35,8 +39,7 @@ const getArticleCarouselData = (elm: HTMLElement): ArticleCarouselProps => {
       const title = q('.ArticleCarouselCard__title', itemElm)?.textContent || '';
       const date = q('.ArticleCarouselCard__date', itemElm)?.textContent || undefined;
       const summary = q('.ArticleCarouselCard__summary', itemElm)?.textContent || '';
-
-      return { href, target, title, date, summary, image, color, theme };
+      return { href, target, title, date, summary, image, color, theme, contextual };
     }
   );
 

--- a/modules/hanna-sprinkles/src/Gallery.tsx
+++ b/modules/hanna-sprinkles/src/Gallery.tsx
@@ -11,8 +11,11 @@ import { getLang } from './_/getLang.js';
 
 const getGalleryData = (elm: HTMLElement): GalleryProps => {
   const lang = getLang(elm);
+  const contextual = q<HTMLDivElement>('.Gallery__contextual', elm)?.innerHTML;
   const items: Array<GalleryItemProps> = qq('.GalleryItem', elm).map(
     (itemElm): GalleryItemProps => {
+      const contextual = q<HTMLDivElement>('.GalleryItem__contextual', itemElm);
+      const contextualChildren = contextual?.innerHTML;
       const img = q<HTMLImageElement>('.GalleryItem__image img', itemElm);
       const caption = q('.GalleryItem__caption', itemElm)?.textContent || undefined;
       const description =
@@ -26,11 +29,12 @@ const getGalleryData = (elm: HTMLElement): GalleryProps => {
         caption,
         largeImageSrc,
         description,
+        contextual: contextualChildren,
       };
     }
   );
 
-  return { items, lang };
+  return { items, lang, contextual };
 };
 
 window.Hanna.makeSprinkle({

--- a/modules/hanna-twig/src/ArticleCarouselItem.twig
+++ b/modules/hanna-twig/src/ArticleCarouselItem.twig
@@ -11,6 +11,7 @@
 {% set targetValue = target ? '_blank' : '_self' %}
 
 <div class="ArticleCarouselCard" {{ colorAttr|raw }} {{ colorThemeAttr|raw }}>
+	{% block contextual %}{% endblock contextual %}
 	<a class="ArticleCarouselCard__link" target={{ targetValue }} href={{ image_link }}>
 		<picture class="ArticleCarouselCard__illustration{{ photoClass }}">
 			{{ image }}

--- a/modules/hanna-twig/src/Gallery.twig
+++ b/modules/hanna-twig/src/Gallery.twig
@@ -1,10 +1,10 @@
 {{ attach_library('hanna/Gallery') }}
 
 <div {{ attributes.addClass('Gallery') }}>
-  {% block contextual %}{% endblock contextual %}
-
-  <div class="Gallery__items">
-    {{ gallery_items }}
+    {% block contextual %}{% endblock contextual %}
+  <div class="Gallery__itemlist-wrapper">
+    <div class="Gallery__itemlist">
+      {{ gallery_items }}
+    </div>
   </div>
-
 </div>

--- a/modules/hanna-twig/src/GalleryItem.twig
+++ b/modules/hanna-twig/src/GalleryItem.twig
@@ -1,5 +1,6 @@
 
 <figure class="GalleryItem">
+  {% block contextual %}{% endblock contextual %}
   {% if figcaption %}
     <figcaption class="GalleryItem__caption">{{ figcaption }}</figcaption>
   {% endif %}
@@ -14,6 +15,6 @@
   {% if description %}
     <div class="GalleryItem__description">
       {{ description }}
-    </div>  
+    </div>
   {% endif %}
 </figure>

--- a/modules/hanna-twig/src/GridBlocks.twig
+++ b/modules/hanna-twig/src/GridBlocks.twig
@@ -10,7 +10,7 @@
 {{ attach_library('hanna/GridBlocks') }}
 
 <div class="GridBlocks__item">
-	{{ frontend_editing }}
+	{% block contextual %}{% endblock contextual %}
 	<picture class="GridBlocks__illustration">
 		{{ grid_image }}
 	</picture>


### PR DESCRIPTION
This PR is related to task:  https://reykjavik-dev.atlassian.net/browse/WEB-155

The goal of this PR is add support to display Drupal Frontend Editing links that Reykjavik requires.

The problem I found was Sprinkles were injecting React component that were not aware of it so it does not matter what Drupal templates add that were never rendered.
To make it possible decided to add a block section named contextual  and  update React templates with the same markup, then sprinkle has also been updated to  retrieve the information to pass it to React component.

@maranomynet I know this add more logic that it is more specific for drupal but I tried to do it as generalistic.
Could you take a look? I would like to know what do you think about it.
If you are not agree and taking into account Reykjavik team want the links I will suggest to create new templates and sprinkles.