### PR TITLE
Fix: Add data-customitem attribute for custom content items in MainMenu2

### DIFF
--- a/modules/hanna-twig/src/MainMenu2.twig
+++ b/modules/hanna-twig/src/MainMenu2.twig
@@ -84,6 +84,7 @@
   <{{Tag}}
     class="{{ classPrefix }}__item{{ item.modifier ? ' ' ~ classPrefix ~ '__item--' ~ item.modifier : '' }}"
     {% if item.current %} aria-current="true" {% endif %}
+    {% if item.content %} data-customitem {% endif %}
   >
     {%- if item.content -%}
       {{ item.content|raw }}


### PR DESCRIPTION
## Summary

This PR fixes a bug where custom content items (like ContextMenu) are filtered out and removed from MainMenu2 after the sprinkle loads.

## Problem

The `make_item` macro in `MainMenu2.twig` was missing the `data-customitem` attribute for items with custom `content`. Without this attribute, the MainMenu2 sprinkle's `parseItem()` function:
1. Can't find an `<a href>` element in custom content (e.g., ContextMenu uses `<details>`)
2. Returns `undefined`
3. The item is filtered out via `.filter(notNully)`
4. **Custom content completely disappears from the rendered menu**

This specifically affects the ContextMenu component when used as a hot item - the language selector disappears after sprinkles load.

## Solution

Added `{% if item.content %} data-customitem {% endif %}` to the `<li>` element in the `make_item` macro.

## Changes

- **File**: `modules/hanna-twig/src/MainMenu2.twig`
- **Line**: ~87
- **Change**: Added conditional `data-customitem` attribute for items with custom content

## Testing

Tested with ContextMenu component as a hot item in MainMenu2:
- ✅ ContextMenu now renders and remains visible after sprinkles load
- ✅ Language selector displays with all languages
- ✅ Dropdown functionality works correctly
- ✅ No regression on standard menu items with links

## Fixes

Closes #51

## Impact

- **Affected Components**: MainMenu2, ContextMenu, and any custom content in hot_items/extra_items/related_items
- **Backward Compatibility**: ✅ Yes - only adds attribute when `item.content` exists
- **Breaking Changes**: None
